### PR TITLE
[feat] 사용자 정보 수정 기능 추가

### DIFF
--- a/src/main/java/com/hicc/nagne_backend/domain/user/application/dto/request/UserRequest.java
+++ b/src/main/java/com/hicc/nagne_backend/domain/user/application/dto/request/UserRequest.java
@@ -11,13 +11,15 @@ public class UserRequest {
         private String name;
         private String description;
         private String email;
+        private String profileUrl;
 
         @Builder
-        public UserUpdateRequest(Long userId, String name, String description, String email) {
+        public UserUpdateRequest(Long userId, String name, String description, String email, String profileUrl) {
             this.userId = userId;
             this.name = name;
             this.description = description;
             this.email = email;
+            this.profileUrl = profileUrl;
         }
     }
 }

--- a/src/main/java/com/hicc/nagne_backend/domain/user/application/dto/request/UserRequest.java
+++ b/src/main/java/com/hicc/nagne_backend/domain/user/application/dto/request/UserRequest.java
@@ -1,0 +1,23 @@
+package com.hicc.nagne_backend.domain.user.application.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class UserRequest {
+
+    @Getter
+    public static class UserUpdateRequest {
+        private Long userId;
+        private String name;
+        private String description;
+        private String email;
+
+        @Builder
+        public UserUpdateRequest(Long userId, String name, String description, String email) {
+            this.userId = userId;
+            this.name = name;
+            this.description = description;
+            this.email = email;
+        }
+    }
+}

--- a/src/main/java/com/hicc/nagne_backend/domain/user/application/dto/resopnse/UserResponse.java
+++ b/src/main/java/com/hicc/nagne_backend/domain/user/application/dto/resopnse/UserResponse.java
@@ -1,4 +1,4 @@
-package com.hicc.nagne_backend.domain.user.application.dto;
+package com.hicc.nagne_backend.domain.user.application.dto.resopnse;
 
 import com.hicc.nagne_backend.domain.trip.application.dto.response.TripResponse;
 import lombok.Builder;

--- a/src/main/java/com/hicc/nagne_backend/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/hicc/nagne_backend/domain/user/application/mapper/UserMapper.java
@@ -1,7 +1,7 @@
 package com.hicc.nagne_backend.domain.user.application.mapper;
 
 import com.hicc.nagne_backend.domain.trip.application.dto.response.TripResponse;
-import com.hicc.nagne_backend.domain.user.application.dto.UserResponse;
+import com.hicc.nagne_backend.domain.user.application.dto.resopnse.UserResponse;
 import com.hicc.nagne_backend.domain.user.domain.entity.User;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -23,4 +23,5 @@ public class UserMapper {
                 .createTripCount(createTripCount)
                 .build();
     }
+
 }

--- a/src/main/java/com/hicc/nagne_backend/domain/user/application/service/UserGetService.java
+++ b/src/main/java/com/hicc/nagne_backend/domain/user/application/service/UserGetService.java
@@ -5,7 +5,7 @@ import com.hicc.nagne_backend.domain.follow.domain.service.FollowingQueryService
 import com.hicc.nagne_backend.domain.trip.application.dto.response.TripResponse;
 import com.hicc.nagne_backend.domain.trip.application.service.TripGetService;
 import com.hicc.nagne_backend.domain.trip.domain.service.TripQueryService;
-import com.hicc.nagne_backend.domain.user.application.dto.UserResponse;
+import com.hicc.nagne_backend.domain.user.application.dto.resopnse.UserResponse;
 import com.hicc.nagne_backend.domain.user.application.mapper.UserMapper;
 import com.hicc.nagne_backend.domain.user.domain.entity.User;
 import com.hicc.nagne_backend.domain.user.domain.service.UserQueryService;

--- a/src/main/java/com/hicc/nagne_backend/domain/user/application/service/UserUpdateService.java
+++ b/src/main/java/com/hicc/nagne_backend/domain/user/application/service/UserUpdateService.java
@@ -1,0 +1,28 @@
+package com.hicc.nagne_backend.domain.user.application.service;
+
+import com.hicc.nagne_backend.domain.user.application.dto.request.UserRequest;
+import com.hicc.nagne_backend.domain.user.domain.entity.User;
+import com.hicc.nagne_backend.domain.user.domain.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserUpdateService {
+
+    private final UserQueryService userQueryService;
+
+    public void updateUser(UserRequest.UserUpdateRequest userUpdateRequest) {
+        Long userId = userUpdateRequest.getUserId();
+        User user = userQueryService.findById(userId);
+
+        String name = userUpdateRequest.getName();
+        String email = userUpdateRequest.getEmail();
+        String description = userUpdateRequest.getDescription();
+
+        user.updateUser(name, description, email);
+
+    }
+}

--- a/src/main/java/com/hicc/nagne_backend/domain/user/application/service/UserUpdateService.java
+++ b/src/main/java/com/hicc/nagne_backend/domain/user/application/service/UserUpdateService.java
@@ -21,8 +21,9 @@ public class UserUpdateService {
         String name = userUpdateRequest.getName();
         String email = userUpdateRequest.getEmail();
         String description = userUpdateRequest.getDescription();
+        String profileUrl = userUpdateRequest.getProfileUrl();
 
-        user.updateUser(name, description, email);
+        user.updateUserInfo(name, description, email, profileUrl);
 
     }
 }

--- a/src/main/java/com/hicc/nagne_backend/domain/user/domain/entity/User.java
+++ b/src/main/java/com/hicc/nagne_backend/domain/user/domain/entity/User.java
@@ -1,17 +1,12 @@
 package com.hicc.nagne_backend.domain.user.domain.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-
 import com.hicc.nagne_backend.common.domain.BaseTimeEntity;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
 
 @Entity
 @Getter
@@ -32,6 +27,12 @@ public class User extends BaseTimeEntity {
 		this.email = email;
 		this.name = name;
 		this.profileUrl = profileUrl;
+		this.description = description;
+	}
+
+	public void updateUser(String name, String description, String email) {
+		this.email = email;
+		this.name = name;
 		this.description = description;
 	}
 }

--- a/src/main/java/com/hicc/nagne_backend/domain/user/domain/entity/User.java
+++ b/src/main/java/com/hicc/nagne_backend/domain/user/domain/entity/User.java
@@ -5,8 +5,10 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -30,9 +32,37 @@ public class User extends BaseTimeEntity {
 		this.description = description;
 	}
 
-	public void updateUser(String name, String description, String email) {
-		this.email = email;
-		this.name = name;
-		this.description = description;
+
+	public void updateUserInfo(String name, String description, String email, String profileUrl){
+		updateName(name);
+		updateDescription(description);
+		updateEmail(email);
+		updateProfileUrl(profileUrl);
 	}
+
+	//검증로직 추가
+	private void updateProfileUrl(String profileUrl) {
+		if (!Objects.equals(this.profileUrl, profileUrl)) { //프로필이 변경되었을 때만
+			this.profileUrl = profileUrl;
+		}
+	}
+
+	private void updateEmail(String email) {
+		if (!Objects.equals(this.email, email) && StringUtils.hasText(email)) { //이메일은 비어있으면 안됨
+			this.email = email;
+		}
+	}
+
+	private void updateDescription(String description) {
+		if (!Objects.equals(this.description, description)) { //설명이 변경되었을 때만
+			this.description = description;
+		}
+	}
+
+	private void updateName(String name) {
+		if (!Objects.equals(this.name, name) && StringUtils.hasText(name)) { //이름은 비어있으면 안됨
+			this.name = name;
+		}
+	}
+
 }

--- a/src/main/java/com/hicc/nagne_backend/domain/user/presentation/UserController.java
+++ b/src/main/java/com/hicc/nagne_backend/domain/user/presentation/UserController.java
@@ -1,20 +1,26 @@
 package com.hicc.nagne_backend.domain.user.presentation;
 
-import com.hicc.nagne_backend.domain.user.application.dto.UserResponse;
+import com.hicc.nagne_backend.domain.user.application.dto.request.UserRequest;
+import com.hicc.nagne_backend.domain.user.application.dto.resopnse.UserResponse;
 import com.hicc.nagne_backend.domain.user.application.service.UserGetService;
+import com.hicc.nagne_backend.domain.user.application.service.UserUpdateService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserGetService userGetService;
+    private final UserUpdateService userUpdateService;
+
     @GetMapping("/user/{userId}")
     public UserResponse.UserInfoResponse getUser(@PathVariable Long userId){
         return userGetService.getUser(userId);
     }
 
+    @PostMapping("/user")   // 4개의 필드 다 바꿀 수 있는건가?
+    public void updateUser(@RequestBody UserRequest.UserUpdateRequest userUpdateRequest) {
+        userUpdateService.updateUser(userUpdateRequest);
+    }
 }


### PR DESCRIPTION
# Summary

사용자 정보 수정 기능 추가


# Issue

User 엔티티에서 profileUrl도 수정가능하게 해야하는지?
사용자가 직접 profileUrl을 수정할 필요는 없다고 판단해서 뺐는데 넣어야한다면 다시 수정하겠음


# References

https://cpdev.tistory.com/168

